### PR TITLE
Scheduler: Support mutable task execution

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -5,8 +5,20 @@ struct PrintExecuter {
     msg: &'static str,
 }
 impl lwos::Execute for PrintExecuter {
-    fn execute(&self, _id: lwos::TaskId) {
+    fn execute(&mut self, _id: lwos::TaskId) {
         println!("{}", self.msg);
+    }
+}
+
+/// Example for mutable executer
+struct CountExecuter {
+    count: usize,
+}
+
+impl lwos::Execute for CountExecuter {
+    fn execute(&mut self, _id: lwos::TaskId) {
+        println!("CountExecuter {}", self.count);
+        self.count = self.count + 1;
     }
 }
 
@@ -14,10 +26,12 @@ fn main() {
     let mut hello_executer = PrintExecuter { msg: "Hello" };
     let mut scheduler_executer = PrintExecuter { msg: "scheduler" };
     let mut world_executer = PrintExecuter { msg: "world!\r\n" };
+    let mut counter_executer = CountExecuter { count: 0usize };
 
     let mut hello_task = lwos::Task::new(lwos::TaskState::Running, &mut hello_executer);
     let mut scheduler_task = lwos::Task::new(lwos::TaskState::Running, &mut scheduler_executer);
     let mut world_task = lwos::Task::new(lwos::TaskState::Running, &mut world_executer);
+    let mut counter_task = lwos::Task::new(lwos::TaskState::Running, &mut counter_executer);
 
     let mut task_ids: [lwos::TaskId; TASKS] = [lwos::INVALID_ID; TASKS];
     let mut scheduler: lwos::Scheduler<TASKS> = lwos::Scheduler::new();
@@ -25,6 +39,7 @@ fn main() {
     task_ids[0] = scheduler.add(&mut hello_task).unwrap();
     task_ids[1] = scheduler.add(&mut scheduler_task).unwrap();
     task_ids[2] = scheduler.add(&mut world_task).unwrap();
+    task_ids[3] = scheduler.add(&mut counter_task).unwrap();
 
     scheduler.process(); // prints "hello scheduler world!
     scheduler.get(task_ids[1]).unwrap().suspend(); // disable "scheduler" print task

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -66,7 +66,7 @@ impl<'a, const SIZE: usize> Scheduler<'a, SIZE> {
     ///
     /// struct SomeExecuter {}
     /// impl Execute for SomeExecuter {
-    ///     fn execute(& self, _id : TaskId) {
+    ///     fn execute(&mut self, _id : TaskId) {
     ///     }
     /// }
     ///
@@ -135,7 +135,7 @@ mod tests {
     use super::*;
     struct SomeExecuter {}
     impl Execute for SomeExecuter {
-        fn execute(&self, _id: TaskId) {}
+        fn execute(&mut self, _id: TaskId) {}
     }
 
     #[test]

--- a/src/task.rs
+++ b/src/task.rs
@@ -16,7 +16,7 @@
 // ************************************************************************************************
 
 pub trait Execute {
-    fn execute(&self, id: TaskId);
+    fn execute(&mut self, id: TaskId);
 }
 
 // ************************************************************************************************
@@ -62,7 +62,7 @@ pub const INVALID_ID: usize = usize::MAX;
 // ************************************************************************************************
 
 impl Execute for NopExecuter {
-    fn execute(&self, _id: TaskId) {}
+    fn execute(&mut self, _id: TaskId) {}
 }
 
 impl<'a> Task<'a> {
@@ -81,7 +81,7 @@ impl<'a> Task<'a> {
     ///
     /// struct SomeExecuter {}
     /// impl Execute for SomeExecuter {
-    ///     fn execute(&self, _id : TaskId) {
+    ///     fn execute(&mut self, _id : TaskId) {
     ///     }
     /// }
     /// let mut executer = SomeExecuter {};
@@ -102,7 +102,7 @@ impl<'a> Task<'a> {
     ///
     /// struct SomeExecuter {}
     /// impl Execute for SomeExecuter {
-    ///     fn execute(&self, _id : TaskId) {
+    ///     fn execute(&mut self, _id : TaskId) {
     ///     }
     /// }
     /// let mut executer = SomeExecuter {};
@@ -117,7 +117,7 @@ impl<'a> Task<'a> {
 
     /// Tries to execute the task dependend on status
     ///
-    pub fn process(&self, id: TaskId) {
+    pub fn process(&mut self, id: TaskId) {
         match self.state {
             TaskState::Running => {
                 self.func.execute(id);
@@ -142,7 +142,7 @@ mod tests {
 
     struct SomeExecuter {}
     impl Execute for SomeExecuter {
-        fn execute(&self, _id: TaskId) {}
+        fn execute(&mut self, _id: TaskId) {}
     }
 
     #[test]


### PR DESCRIPTION
Make task executer mutable to allow changing task context data.